### PR TITLE
deps: bump agents version (for remaining plugins)

### DIFF
--- a/livekit-plugins/livekit-plugins-aliyun/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-aliyun/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 keywords = ["webrtc", "realtime", "audio", "video", "livekit"]
 requires-python = ">=3.9"
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
     "osc-data>=0.2.2",
 ]
 

--- a/livekit-plugins/livekit-plugins-baidu/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-baidu/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
 ]
 
 

--- a/livekit-plugins/livekit-plugins-dify/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-dify/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
 ]
 
 

--- a/livekit-plugins/livekit-plugins-flashtts/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-flashtts/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 keywords = ["webrtc", "realtime", "audio", "video", "livekit"]
 requires-python = ">=3.9"
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
     "osc-data>=0.2.2",
     "pydantic",
 ]

--- a/livekit-plugins/livekit-plugins-minimax/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-minimax/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "osc-data>=0.2.2",
     "pydantic",
     "openai",
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
 ]
 
 classifiers = [

--- a/livekit-plugins/livekit-plugins-stepfun/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-stepfun/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 keywords = ["webrtc", "realtime", "audio", "video", "livekit"]
 requires-python = ">=3.9"
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
     "openai>=1.75.0",
 ]
 

--- a/livekit-plugins/livekit-plugins-xunfei/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-xunfei/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 keywords = ["webrtc", "realtime", "audio", "video", "livekit"]
 requires-python = ">=3.9"
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
 ]
 
 classifiers = [

--- a/livekit-plugins/livekit-plugins-zhipu/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-zhipu/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 keywords = ["webrtc", "realtime", "audio", "video", "livekit"]
 requires-python = ">=3.9"
 dependencies = [
-    "livekit-agents==1.2.9",
+    "livekit-agents>=1.4.0",
     "openai>=1.75.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ livekit-plugins-dify = { workspace = true}
 livekit-plugins-flashtts = { workspace = true}
 livekit-plugins-aliyun = { workspace = true}
 
+[tool.uv]
+constraint-dependencies = ['onnxruntime<1.24; python_version < "3.11"']
+
 [tool.uv.workspace]
 members = ["livekit-plugins/*"]
 


### PR DESCRIPTION
Since current agents deps are not the same for different plugins
- tecent and volcengine are >= 1.4.0
- others are == 1.2.9
I encountered error when use `uv sync`
```
Because livekit-plugins-aliyun depends on livekit-agents==1.2.9 and livekit-plugins-tencent depends
      on livekit-agents>=1.4.0, we can conclude that livekit-plugins-aliyun and livekit-plugins-tencent
      are incompatible.
      And because your workspace requires livekit-plugins-aliyun and livekit-plugins-tencent, we can
      conclude that your workspace's requirements are unsatisfiable.
```
So I just bump all agents version to >= 1.4.0. Not sure if other plugins support agents >= 1.4.0, will close this PR if other plugins do not support higher agents version.